### PR TITLE
feat: add browser-default homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ add this to your html:
 
 Fetches the favicon for a given URL.
 
+Without a `url` parameter, this endpoint serves an HTML usage page.
+
 **Parameters:**
 - `url` (required): The URL to fetch the favicon for
 

--- a/assets/efs.go
+++ b/assets/efs.go
@@ -2,5 +2,5 @@ package assets
 
 import "embed"
 
-//go:embed "static" "migrations"
+//go:embed "static" "templates" "migrations"
 var Embeddedfiles embed.FS

--- a/assets/templates/404.html
+++ b/assets/templates/404.html
@@ -1,0 +1,9 @@
+{{define "content"}}
+<article>
+    <h1>404</h1>
+    <p>Page not found.</p>
+    <nav>
+        <a href="/">← Back to home</a>
+    </nav>
+</article>
+{{end}}

--- a/assets/templates/base.html
+++ b/assets/templates/base.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{.Title}}</title>
+    <link rel="icon" type="image/x-icon" href="/favicon.ico">
+    <script defer src="https://umami.jaw.dev/script.js" data-website-id="9540e369-b296-424d-913f-436a46d11745"></script>
+</head>
+<body>
+    <main>
+        {{template "content" .}}
+    </main>
+
+    <footer>
+        <p>
+            Copyright © 2026. Made with ❤️ by <a href="https://github.com/wajeht">@wajeht</a>
+            |
+            <a href="https://github.com/wajeht/favicon" target="_blank" rel="noopener noreferrer">Github</a>
+        </p>
+    </footer>
+</body>
+</html>

--- a/assets/templates/domains.html
+++ b/assets/templates/domains.html
@@ -1,0 +1,29 @@
+{{define "content"}}
+<header>
+    <h1>🌐 Domains</h1>
+    <p>Cached favicons ({{len .Domains}} total)</p>
+</header>
+
+<table style="border-collapse: collapse;" border="1">
+    <thead>
+        <tr>
+            <th>id</th>
+            <th>domain</th>
+            <th>data</th>
+            <th>content_type</th>
+            <th>created_at</th>
+        </tr>
+    </thead>
+    <tbody>
+        {{range .Domains}}
+        <tr>
+            <td>{{.ID}}</td>
+            <td>{{.Domain}}</td>
+            <td><img loading="lazy" src="/?url={{.Domain}}" alt="{{.Domain}} favicon" width="16" height="16"> {{.DataSize}} bytes</td>
+            <td>{{.ContentType}}</td>
+            <td>{{.CreatedAt}}</td>
+        </tr>
+        {{end}}
+    </tbody>
+</table>
+{{end}}

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -11,23 +11,6 @@
     </section>
 
     <section>
-        <h2>Try It</h2>
-        <form action="/" method="get">
-            <label for="url">Website URL</label>
-            <input id="url" name="url" type="text" value="github.com" required>
-            <button type="submit">Get favicon</button>
-        </form>
-    </section>
-
-    <section>
-        <h2>Demo</h2>
-        <p>
-            <img loading="lazy" src="/?url=github.com" width="16" height="16" alt="GitHub favicon">
-            GitHub favicon
-        </p>
-    </section>
-
-    <section>
         <h2>Options</h2>
         <dl>
             <dt><code>url</code></dt>

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -1,6 +1,6 @@
 {{define "content"}}
 <header>
-    <h1>🔖 Favicon</h1>
+    <h1>🌐 Favicon</h1>
     <p>Automagically grab the favicon of a URL.</p>
 </header>
 

--- a/assets/templates/index.html
+++ b/assets/templates/index.html
@@ -1,0 +1,44 @@
+{{define "content"}}
+<header>
+    <h1>🔖 Favicon</h1>
+    <p>Automagically grab the favicon of a URL.</p>
+</header>
+
+<article>
+    <section>
+        <h2>Basic Usage</h2>
+        <pre><code>&lt;img loading="lazy" src="https://favicon.jaw.dev?url=github.com" /&gt;</code></pre>
+    </section>
+
+    <section>
+        <h2>Try It</h2>
+        <form action="/" method="get">
+            <label for="url">Website URL</label>
+            <input id="url" name="url" type="text" value="github.com" required>
+            <button type="submit">Get favicon</button>
+        </form>
+    </section>
+
+    <section>
+        <h2>Demo</h2>
+        <p>
+            <img loading="lazy" src="/?url=github.com" width="16" height="16" alt="GitHub favicon">
+            GitHub favicon
+        </p>
+    </section>
+
+    <section>
+        <h2>Options</h2>
+        <dl>
+            <dt><code>url</code></dt>
+            <dd>URL to fetch the favicon for (required)</dd>
+        </dl>
+    </section>
+
+    <section>
+        <h2>Examples</h2>
+        <pre><code>/?url=github.com
+/?url=https://example.com</code></pre>
+    </section>
+</article>
+{{end}}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html"
 	"html/template"
 	"image"
 	"image/jpeg"
@@ -74,6 +73,19 @@ var (
 
 type PageData struct {
 	Title string
+}
+
+type DomainEntry struct {
+	ID          int    `json:"id"`
+	Domain      string `json:"domain"`
+	DataSize    int    `json:"data_size"`
+	ContentType string `json:"content_type"`
+	CreatedAt   string `json:"created_at"`
+}
+
+type DomainsPageData struct {
+	Title   string
+	Domains []DomainEntry
 }
 
 type FaviconResult struct {
@@ -632,7 +644,7 @@ func stripTrailingSlashMiddleware(next http.Handler) http.Handler {
 
 func parseTemplates() (map[string]*template.Template, error) {
 	templates := make(map[string]*template.Template)
-	pages := []string{"index", "404"}
+	pages := []string{"index", "404", "domains"}
 
 	base, err := assets.Embeddedfiles.ReadFile("templates/base.html")
 	if err != nil {
@@ -803,13 +815,7 @@ func handleDomains(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var domains []struct {
-		ID          int    `json:"id"`
-		Domain      string `json:"domain"`
-		DataSize    int    `json:"data_size"`
-		ContentType string `json:"content_type"`
-		CreatedAt   string `json:"created_at"`
-	}
+	var domains []DomainEntry
 	if err := json.Unmarshal([]byte(jsonResult), &domains); err != nil {
 		log.Printf("Error parsing domains: %v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
@@ -818,49 +824,12 @@ func handleDomains(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Header().Set("Cache-Control", fmt.Sprintf("public, max-age=%d, must-revalidate", listCacheTTL))
-	w.WriteHeader(http.StatusOK)
-
-	fmt.Fprintf(w, `<!DOCTYPE html>
-<html>
-<head>
-<title>Domains</title>
-<style>
-body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
-table { border-collapse: collapse; width: 100%%; margin: 20px auto; }
-th, td { padding: 12px; text-align: left; border-bottom: 1px solid #ddd; }
-th { background-color: #f5f5f5; font-weight: bold; position: sticky; top: 0; }
-tr:hover { background-color: #f9f9f9; }
-td:first-child, th:first-child { text-align: center; }
-</style>
-<script defer src="https://umami.jaw.dev/script.js" data-website-id="9540e369-b296-424d-913f-436a46d11745"></script>
-</head>
-<body>
-<table>
-<thead>
-<tr>
-<th>id</th>
-<th>domain</th>
-<th>data</th>
-<th>content_type</th>
-<th>created_at</th>
-</tr>
-</thead>
-<tbody>
-`)
-	for _, d := range domains {
-		fmt.Fprintf(w, "<tr><td>%d</td><td>%s</td><td><img loading=\"lazy\" src=\"/?url=%s\" alt=\"%s favicon\" style=\"width: 16px; height: 16px;\" /> %d bytes</td><td>%s</td><td>%s</td></tr>\n",
-			d.ID,
-			html.EscapeString(d.Domain),
-			html.EscapeString(d.Domain),
-			html.EscapeString(d.Domain),
-			d.DataSize,
-			html.EscapeString(d.ContentType),
-			html.EscapeString(d.CreatedAt))
+	if err := pageTemplates["domains"].Execute(w, DomainsPageData{
+		Title:   "Domains",
+		Domains: domains,
+	}); err != nil {
+		log.Printf("Error rendering domains page: %v", err)
 	}
-	fmt.Fprintf(w, `</tbody>
-</table>
-</body>
-</html>`)
 }
 
 func handleHealthz(w http.ResponseWriter, r *http.Request) {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"html"
+	"html/template"
 	"image"
 	"image/jpeg"
 	"image/png"
@@ -67,7 +68,13 @@ var (
 	repo *FaviconRepository
 
 	httpClient = newHTTPClient()
+
+	pageTemplates = mustParseTemplates()
 )
+
+type PageData struct {
+	Title string
+}
 
 type FaviconResult struct {
 	Data        []byte
@@ -623,15 +630,66 @@ func stripTrailingSlashMiddleware(next http.Handler) http.Handler {
 	})
 }
 
+func parseTemplates() (map[string]*template.Template, error) {
+	templates := make(map[string]*template.Template)
+	pages := []string{"index", "404"}
+
+	base, err := assets.Embeddedfiles.ReadFile("templates/base.html")
+	if err != nil {
+		return nil, fmt.Errorf("reading base template: %w", err)
+	}
+
+	for _, page := range pages {
+		content, err := assets.Embeddedfiles.ReadFile("templates/" + page + ".html")
+		if err != nil {
+			return nil, fmt.Errorf("reading %s template: %w", page, err)
+		}
+
+		tmpl, err := template.New("base").Parse(string(base))
+		if err != nil {
+			return nil, fmt.Errorf("parsing base template: %w", err)
+		}
+
+		tmpl, err = tmpl.Parse(string(content))
+		if err != nil {
+			return nil, fmt.Errorf("parsing %s template: %w", page, err)
+		}
+
+		templates[page] = tmpl
+	}
+
+	return templates, nil
+}
+
+func mustParseTemplates() map[string]*template.Template {
+	templates, err := parseTemplates()
+	if err != nil {
+		panic(err)
+	}
+
+	return templates
+}
+
+func handleNotFound(w http.ResponseWriter) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusNotFound)
+	if err := pageTemplates["404"].Execute(w, PageData{Title: "404 - Not Found"}); err != nil {
+		log.Printf("Error rendering not found page: %v", err)
+	}
+}
+
 func handleHome(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
-		http.Error(w, "The requested resource could not be found", http.StatusNotFound)
+		handleNotFound(w)
 		return
 	}
 
 	rawURL := r.URL.Query().Get("url")
 	if rawURL == "" {
-		http.Error(w, "Missing 'url' query parameter. Usage: /?url=<url>", http.StatusBadRequest)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		if err := pageTemplates["index"].Execute(w, PageData{Title: "Favicon"}); err != nil {
+			log.Printf("Error rendering home page: %v", err)
+		}
 		return
 	}
 

--- a/main_test.go
+++ b/main_test.go
@@ -463,7 +463,7 @@ func TestHandleHomePage(t *testing.T) {
 	if contentType := w.Header().Get("Content-Type"); contentType != "text/html; charset=utf-8" {
 		t.Errorf("expected HTML content type, got %q", contentType)
 	}
-	if body := w.Body.String(); !strings.Contains(body, "<h1>🔖 Favicon</h1>") {
+	if body := w.Body.String(); !strings.Contains(body, "<h1>🌐 Favicon</h1>") {
 		t.Errorf("expected favicon homepage, got %q", body)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -610,8 +610,14 @@ func TestHandleDomainsHTML(t *testing.T) {
 
 	body := w.Body.String()
 
-	if !strings.Contains(body, "<table>") {
+	if !strings.Contains(body, "<table") {
 		t.Error("Response should contain table element")
+	}
+	if !strings.Contains(body, "<h1>🌐 Domains</h1>") {
+		t.Error("Response should contain domains header")
+	}
+	if !strings.Contains(body, "Copyright © 2026") {
+		t.Error("Response should contain shared footer")
 	}
 	if !strings.Contains(body, "<th>id</th>") {
 		t.Error("Response should contain 'id' header")

--- a/main_test.go
+++ b/main_test.go
@@ -38,6 +38,23 @@ func TestExtractDomain(t *testing.T) {
 	}
 }
 
+func TestHandleNotFoundPage(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/missing", nil)
+	rec := httptest.NewRecorder()
+
+	handleHome(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("expected status %d, got %d", http.StatusNotFound, rec.Code)
+	}
+	if contentType := rec.Header().Get("Content-Type"); contentType != "text/html; charset=utf-8" {
+		t.Errorf("expected HTML content type, got %q", contentType)
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "<h1>404</h1>") {
+		t.Errorf("expected not found page, got %q", body)
+	}
+}
+
 func TestIsValidImageType(t *testing.T) {
 	tests := []struct {
 		contentType string
@@ -434,17 +451,20 @@ func TestHandleFavicon(t *testing.T) {
 	}
 }
 
-func TestHandleHomeMissingURL(t *testing.T) {
-	repo = setupTestDB(t)
-	defer teardownTestDB(t)
-
+func TestHandleHomePage(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 	w := httptest.NewRecorder()
 
 	handleHome(w, req)
 
-	if w.Code != http.StatusBadRequest {
-		t.Errorf("Expected status %d, got %d", http.StatusBadRequest, w.Code)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status %d, got %d", http.StatusOK, w.Code)
+	}
+	if contentType := w.Header().Get("Content-Type"); contentType != "text/html; charset=utf-8" {
+		t.Errorf("expected HTML content type, got %q", contentType)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "<h1>🔖 Favicon</h1>") {
+		t.Errorf("expected favicon homepage, got %q", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- serve an HTML usage page when `/` is opened without a `url` parameter
- match the Screenshot project’s browser-default HTML theme and shared footer
- render `/domains` through the same shared layout while preserving JSON responses
- add a matching HTML 404 page while preserving favicon API responses
- embed the templates in the Go binary and document the homepage behavior

## Impact

Visitors now get consistent, concise HTML pages across the service. Existing `/?url=...` favicon requests and `/domains?format=json` responses continue to work as before.

## Validation

- `go test -count=1 ./...`
- `go build -o /tmp/favicon-build .`
- `git diff --check`